### PR TITLE
Use the correct Solidus dateFormat

### DIFF
--- a/app/assets/javascripts/spree/backend/solidus_sale_prices.js
+++ b/app/assets/javascripts/spree/backend/solidus_sale_prices.js
@@ -3,7 +3,7 @@
 SpreeSalePrices = {
   handleDatetimePickerFields: function() {
     $('.datetimepicker').datetimepicker({
-      dateFormat: Spree.translations.date_picker,
+      dateFormat: Spree.translations.date_picker.js_format,
       timeFormat: "hh:mm tt",
       dayNames: Spree.translations.abbr_day_names,
       dayNamesMin: Spree.translations.abbr_day_names,


### PR DESCRIPTION
The datetimepicker allow to override the date and time format. We
changed the format using the correct Solidus JS format.